### PR TITLE
Allow segmentation on any path

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,8 +4,6 @@
 var express = require('ft-next-express');
 var app = module.exports = express();
 
-app.get('/ab', require('./controllers/grouper'));
-
 app.get('/__gtg', function(req, res) {
 	res.status(200).send('OK');
 });
@@ -13,6 +11,8 @@ app.get('/__gtg', function(req, res) {
 app.get('/', function(req, res) {
 	res.redirect(302, 'https://github.com/financial-times/next-ab');
 });
+
+app.get(/(.*)/, require('./controllers/grouper'));
 
 module.exports.listen = app.listen(process.env.PORT, function() {
 	console.log("Listening on port", process.env.PORT);

--- a/test/ab.test.js
+++ b/test/ab.test.js
@@ -12,7 +12,7 @@ describe('ab tests', function() {
 
 	it("Allocate users to a control group", function(done) {
 		request(app)
-			.get('/ab')
+			.get('/whatever/we/want')
 			.set('X-FT-User-Id', 1)
 			.expect(function (res) {
 				var allocation = res.headers['x-ft-ab'];


### PR DESCRIPTION
Varnish will send the request pathname to the AB segmentation service.

To keep things simple (i.e. not-rewriting URLs in VCL) the AB test can
accept requests on any URL.