### PR TITLE
Use allocation id if we have it

### DIFF
--- a/server/promise-of-id.js
+++ b/server/promise-of-id.js
@@ -15,16 +15,21 @@ module.exports = function(req) {
 	var allocationId = req.get('ft-allocation-id');
 	var isAnonymous = !sessionToken && !allocationId;
 
-	if (sessionToken) {
-		metrics.count('id.has-session-token', 1);
-	}
-
 	if (allocationId) {
 		metrics.count('id.has-allocation-id', 1);
 	}
 
+	if (sessionToken) {
+		metrics.count('id.has-session-token', 1);
+	}
+
 	if (isAnonymous) {
 		metrics.count('id.is-anonymous', 1);
+	}
+
+	// If an allocation ID is provided, use that.
+	if (allocationId) {
+		return Promise.resolve(allocationId);
 	}
 
 	// If an ft-session-token is provided, attempt to load uuid via the session api.
@@ -43,11 +48,6 @@ module.exports = function(req) {
 		.then(function(json) {
 			return json.uuid;
 		});
-	}
-
-	// If an allocation ID is provided, use that.
-	if (allocationId) {
-		return Promise.resolve(allocationId);
 	}
 
 	// If neither ft-session-token nor allocation ID were provided,

--- a/test/promise-of-id.test.js
+++ b/test/promise-of-id.test.js
@@ -49,8 +49,11 @@ describe('Promise of ID', function () {
 			res.end();
 		});
 
+		var get = sinon.stub();
+		get.withArgs('ft-session-token').returns('z3MN_fJbrEOi07YfudMM2Trlzw');
+
 		var req = {
-			get: sinon.stub().returns('z3MN_fJbrEOi07YfudMM2Trlzw')
+			get: get
 		};
 
 		promiseOfId(req)


### PR DESCRIPTION
@commuterjoy I think this makes sense. If we have the allocation ID we just want to return with this immediately rather than calling session?